### PR TITLE
Add support for memcached rediscloud endpoints, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This buildpack contains only small changes from the base [Heroku Redis Buildpack
 First you need to set this buildpack as your initial buildpack with:
 
 ```console
-$ heroku buildpacks:add -i 1 https://github.com/faros-ai/heroku-buildpack-redis-cloud.git
+$ heroku buildpacks:add -i 1 https://github.com/Yesware/heroku-buildpack-redis-cloud.git
 ```
 
 Then confirm you are using this buildpack as well as your language buildpack like so:
@@ -22,7 +22,7 @@ Then confirm you are using this buildpack as well as your language buildpack lik
 ```console
 $ heroku buildpacks
 === frozen-potato-95352 Buildpack URLs
-1. https://github.com/faros-ai/heroku-buildpack-redis-cloud.git
+1. https://github.com/Yesware/heroku-buildpack-redis-cloud.git
 2. heroku/python
 ```
 
@@ -69,7 +69,7 @@ We're then ready to deploy to Heroku with an encrypted connection between the dy
     ...
     -----> Fetching custom git buildpack... done
     -----> Multipack app detected
-    =====> Downloading Buildpack: https://github.com/faros-ai/heroku-buildpack-redis-cloud.git
+    =====> Downloading Buildpack: https://github.com/Yesware/heroku-buildpack-redis-cloud.git
     =====> Detected Framework: stunnel
            Using stunnel version: 5.02
            Using stack version: cedar

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -36,17 +36,28 @@ EOFEOF
 for URL in $URLS
 do
   eval URL_VALUE=\$$URL
-  PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2 $3 $4 $5 $6 $7" if /^([^:]+):\/\/([^:]+):([^@]+)@(.*?):(.*?)(\/(.*?)(\\?.*))?$/')
-  URI=( $PARTS )
-  URI_SCHEME=${URI[0]}
-  URI_USER=${URI[1]}
-  URI_PASS=${URI[2]}
-  URI_HOST=${URI[3]}
-  URI_PORT=${URI[4]}
+  if [[ ${URL_VALUE} =~ "memcached-" ]]; then
+    PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2" if /^(.*?):(.*?)$/')
+    URI=( $PARTS )
+    URI_HOST=${URI[0]}
+    URI_PORT=${URI[1]}
 
-  echo "Setting ${URL}_STUNNEL config var"
-  export ${URL}_STUNNEL=$URI_SCHEME://$URI_USER:$URI_PASS@127.0.0.1:637${n}
+    echo "Setting ${URL}_STUNNEL config var"
+    export ${URL}_STUNNEL=127.0.0.1:637${n}
 
+  else
+    PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2 $3 $4 $5 $6 $7" if /^([^:]+):\/\/([^:]+):([^@]+)@(.*?):(.*?)(\/(.*?)(\\?.*))?$/')
+    URI=( $PARTS )
+    URI_SCHEME=${URI[0]}
+    URI_USER=${URI[1]}
+    URI_PASS=${URI[2]}
+    URI_HOST=${URI[3]}
+    URI_PORT=${URI[4]}
+
+    echo "Setting ${URL}_STUNNEL config var"
+    export ${URL}_STUNNEL=$URI_SCHEME://$URI_USER:$URI_PASS@127.0.0.1:637${n}
+
+  fi
   cat >> /app/vendor/stunnel/stunnel.conf << EOFEOF
 [$URL]
 client = yes


### PR DESCRIPTION
Adds the ability for the stunnel buildpack to deal with the redis cloud memcached endpoints when using the `dalli` gem and the associated `MEMCACHE_SERVERS` env var.

```
irb(main):001:0> require 'dalli'
=> true

irb(main):002:0> options = { :namespace => "lolcats", :server => ENV['MEMCACHE_SERVERS'], :username => ENV['MEMCACHE_USERNAME'], :password => ENV['MEMCACHE_PASSWORD'] }
=> {:namespace=>"lolcats", :server=>"127.0.0.1:6372", :username=>"<REDACTED>", :password=>"<REDACTED>"}

irb(main):003:0> dc = Dalli::Client.new(options)
=> #<Dalli::Client:0x000055dcfb5a1940 @servers=["127.0.0.1:6372"], @options={:expires_in=>0}, @ring=nil>

irb(main):004:0> dc.set('lolcats', '02111')
2020.06.23 13:45:21 LOG5[0]: Service [MEMCACHE_SERVERS] accepted connection from 127.0.0.1:39586
2020.06.23 13:45:22 LOG5[0]: s_connect: connected 54.<REDACTED>.110:15754
2020.06.23 13:45:22 LOG5[0]: Service [MEMCACHE_SERVERS] connected remote server from 172.18.183.118:60364
2020.06.23 13:45:22 LOG5[0]: Certificate accepted at depth=0: CN=*.<REDACTED>.cloud.rlrcp.com
I, [2020-06-23T13:45:22.075783 #4]  INFO -- : Dalli/SASL authenticating as <REDACTED>
I, [2020-06-23T13:45:22.077083 #4]  INFO -- : Dalli/SASL: Authenticated
=> true

irb(main):005:0> dc.get('lolcats')
=> "02111"
```
Also update the README for our repo